### PR TITLE
Set useQueryString to True for array query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Fetching riot games api data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -217,6 +217,7 @@ export class BaseApi<Region extends string> {
         'X-Riot-Token': this.key
       },
       qs,
+      useQuerystring: true,
       resolveWithFullResponse: true,
       json: true
     }


### PR DESCRIPTION
When array query are passed to twisted, it sends get request with wrong query.
e.g. Get matchlist filtered by multiple queue id:
```JavaScript
qs: {
    queue: [420, 430]
}
```
Currently twisted constructs wrong url:
```
/lol/match/v4/matchlists/by-account/xxx?queue%5B0%5D=420&queue%5B1%5D=430
```

To handle array query, useQueryString should be true. 
[request doc :](https://github.com/request/request#requestoptions-callback)
```
useQuerystring - if true, use querystring to stringify and parse querystrings, otherwise use qs (default: false). Set this option to true if you need arrays to be serialized as foo=bar&foo=baz instead of the default foo[0]=bar&foo[1]=baz.
```

With useQueryString, the above query can be handled correctly:
```
/lol/match/v4/matchlists/by-account/xxx?queue=420&queue=430
```