### PR TITLE
Fix debug url and add test for getUrlFromOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "Fetching riot games api data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/base/base.utils.ts
+++ b/src/base/base.utils.ts
@@ -1,4 +1,5 @@
 import { OptionsWithUri } from 'request'
+import qs from 'querystring';
 
 export interface IParams {
   [key: string]: string | number
@@ -53,10 +54,7 @@ export function getUrlFromOptions (options: OptionsWithUri): string {
   let uri = options.uri as string
   if (options.qs) {
     uri += '?'
-    for (const key in options.qs) {
-      const value = encodeURIComponent(options.qs[key])
-      uri += `${key}=${value}`
-    }
+    uri += qs.stringify(options.qs);
   }
   return uri
 }

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,6 +1,7 @@
 const { describe, it } = require('mocha')
 const { expect } = require('chai')
 const { BaseApi } = require('../src/base/base')
+const { getUrlFromOptions } = require('../src/base/base.utils')
 const { ApiKeyNotFound, RateLimitError, ServiceUnavailable } = require('../src/errors')
 const { restore, stub } = require('sinon')
 
@@ -83,6 +84,17 @@ describe('Base api', () => {
       const ends = 'ryze/wood'
       const url = riot.getApiUrl(baseEndpoint, params)
       expect(url.endsWith(ends)).to.be.equal(true)
+    })
+
+    it('should return correct url with query params', () => {
+      const baseUrl = 'https://na.api.riotgames.com/lol/match/v4/matchlists/by-account/xxx'
+      const options = {
+        uri: baseUrl,
+        qs: { queue: [ 420, 430 ], beginIndex: 0, endIndex: 10 }
+      }
+      const url = getUrlFromOptions(options);
+      const exp = `${baseUrl}?queue=420&queue=430&beginIndex=0&endIndex=10`
+      expect(url).equal(exp)
     })
   })
 


### PR DESCRIPTION
Use [querystring.stringify](https://nodejs.org/api/querystring.html#querystring_querystring_stringify_obj_sep_eq_options) instead of combining repeated params.
This fixes logger output ('&' are missed out and array query couldn't be parsed correctly).
Before:
```
Calling method url: https://jp1.api.riotgames.com/lol/match/v4/matchlists/by-account/xxx?queue=420%2C430beginIndex=0endIndex=10
```

After:
```
Calling method url: https://jp1.api.riotgames.com/lol/match/v4/matchlists/by-account/xxx?queue=420&queue=430&beginIndex=0&endIndex=10
```