### PR TITLE
Add game_variation to TFTMatchInfo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.17.0",
+  "version": "1.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "Fetching riot games api data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/models-dto/matches/tft-matches/info.dto.ts
+++ b/src/models-dto/matches/tft-matches/info.dto.ts
@@ -14,6 +14,10 @@ export class InfoDto {
    */
   readonly tft_set_number: number
   /**
+   * Teamfight Taxtics game variant
+   */
+  readonly game_variation: string
+  /**
    * Game length in seconds.
    */
   readonly game_length: number


### PR DESCRIPTION
`game_variation` was added to the api but not yet to the documentation, it could have one of these values: `['TFT3_GameVariation_None', 'TFT3_GameVariation_FreeNeekos', 'TFT3_GameVariation_FourCostFirstCarousel']`;