### PR TITLE
Bugfix: mapId: string -> mapId: number

### DIFF
--- a/src/models-dto/matches/match/match.dto.ts
+++ b/src/models-dto/matches/match/match.dto.ts
@@ -37,7 +37,7 @@ export class MatchDto {
   /**
    * Please refer to the Game Constants documentation.
    */
-  mapId: string
+  mapId: number
   /**
    * Please refer to the Game Constants documentation.
    */


### PR DESCRIPTION
Map is is actually a number but was incorrectly marked 
Fixes #51