### PR TITLE
Added unref() call to updateChampionsIDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.44.3",
+  "version": "1.45.3",
   "description": "Fetching riot games api data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants/champions.ts
+++ b/src/constants/champions.ts
@@ -189,7 +189,7 @@ if (process.env.UPDATE_CHAMPION_IDS) {
     }
   }
   // Schedule once every day.
-  setInterval(updateChampionIDs, 1000 * 60 * 60 * 24)
+  setInterval(updateChampionIDs, 1000 * 60 * 60 * 24).unref()
   updateChampionIDs()
 }
 


### PR DESCRIPTION
 functionality so this function alone does not keep the process using this library alive. [Reference](https://nodejs.org/api/timers.html#timers_timeout_unref)

Context: I've added this feature around last christmas, but eventually i figured out that it keeps programs using this feature alive, because the 24 hour interval is not properly unref'd.