### PR TITLE
Fix isRateLimitError and isServiceUnavailableError

### DIFF
--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -114,20 +114,14 @@ export class BaseApi<Region extends string> {
     if (!e) {
       return false
     }
-    const {
-      statusCode = e.status
-    } = e || e.error
-    return statusCode === TOO_MANY_REQUESTS
+    return e.response.status === TOO_MANY_REQUESTS
   }
 
   private isServiceUnavailableError (e: any) {
     if (!e) {
       return false
     }
-    const {
-      statusCode = e.status
-    } = e || e.error
-    return statusCode === SERVICE_UNAVAILABLE
+    return e.response.status === SERVICE_UNAVAILABLE
   }
 
   private getError (e: any) {


### PR DESCRIPTION
As they are now, these two functions always return false, because `e.status` is undefined. I'm guessing this was caused by the switch to Axios.

Using `e.response.status` fixes the problem.

I also got rid of the `e || e.error` pattern because `if (!e) return false` ensures that `e` will always be truthy at that point.