### PR TITLE
Added start and end time to MatchQueryV5DTO

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.46.3",
+  "version": "1.46.4",
   "description": "Fetching riot games api data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/models-dto/matches/query-v5/match-query-v5.dto.ts
+++ b/src/models-dto/matches/query-v5/match-query-v5.dto.ts
@@ -3,4 +3,6 @@ export class MatchQueryV5DTO {
   queue?: number
   start?: number
   type?: string
+  startTime?: number
+  endTime?: number
 }


### PR DESCRIPTION
fixes #63 
Added startTime and endTime to the MatchQueryV5DTO as documented in: https://developer.riotgames.com/apis#match-v5/GET_getMatchIdsByPUUID