### PR TITLE
fix: Champion-V4 deprecated by-summoner endpoints

### DIFF
--- a/example/lol/ChampionMasteryByPUUID.example.ts
+++ b/example/lol/ChampionMasteryByPUUID.example.ts
@@ -3,12 +3,12 @@ import { config } from '../config/config'
 
 const api = new LolApi()
 
-export async function championMasteryBySummoner () {
+export async function championMasteryByPUUID () {
   const { region } = config
   const {
     response: {
       id
     }
   } = await api.Summoner.getByName(config.summonerName, region)
-  return await api.Champion.masteryBySummoner(id, region)
+  return await api.Champion.masteryByPUUID(id, region)
 }

--- a/example/lol/ChampionMasteryByPUUIDChampion.example.ts
+++ b/example/lol/ChampionMasteryByPUUIDChampion.example.ts
@@ -3,12 +3,12 @@ import { config } from '../config/config'
 
 const api = new LolApi()
 
-export async function championMasteryBySummonerByChampion () {
+export async function championMasteryByPUUIDByChampion () {
   const { region } = config
   const {
     response: {
       id
     }
   } = await api.Summoner.getByName(config.summonerName, region)
-  return await api.Champion.masteryBySummonerChampion(id, 1, region)
+  return await api.Champion.masteryByPUUIDChampion(id, 1, region)
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.56.2",
+  "version": "1.56.3",
   "description": "Fetching riot games api data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/apis/lol/champion/champion.ts
+++ b/src/apis/lol/champion/champion.ts
@@ -17,35 +17,35 @@ export class ChampionApi extends BaseApiLol {
   }
   /**
    * Champion mastery by summoner
-   * @param encryptedSummonerId
+   * @param puuid
    * @param region
    */
-  public async masteryBySummoner (encryptedSummonerId: string, region: Regions) {
+  public async masteryByPUUID (puuid: string, region: Regions) {
     const params = {
-      encryptedSummonerId
+      puuid
     }
-    return this.request<ChampionMasteryDTO[]>(region, endpointsV4.ChampionMasteryBySummoner, params)
+    return this.request<ChampionMasteryDTO[]>(region, endpointsV4.ChampionMasteryByPUUID, params)
   }
   /**
    * Champion mastery by summoner
-   * @param encryptedSummonerId
+   * @param puuid
    * @param region
    */
-  public async masteryBySummonerChampion (encryptedSummonerId: string, championId: number, region: Regions) {
+  public async masteryByPUUIDChampion (puuid: string, championId: number, region: Regions) {
     const params = {
-      encryptedSummonerId,
+      puuid,
       championId
     }
-    return this.request<ChampionMasteryDTO>(region, endpointsV4.ChampionMasteryBySummonerChampion, params)
+    return this.request<ChampionMasteryDTO>(region, endpointsV4.ChampionMasteryByPUUIDChampion, params)
   }
   /**
    * Champions mastery score
-   * @param encryptedSummonerId
+   * @param puuid
    * @param region
    */
-  public async championsScore (encryptedSummonerId: string, region: Regions): Promise<ChampionsScoreDTO> {
+  public async championsScore (puuid: string, region: Regions): Promise<ChampionsScoreDTO> {
     const params = {
-      encryptedSummonerId
+      puuid
     }
     let {
       response: score

--- a/src/endpoints/endpoints.ts
+++ b/src/endpoints/endpoints.ts
@@ -92,18 +92,18 @@ export const endpointsV4: IEndpoints = {
     prefix: 'platform',
     version: 4
   },
-  ChampionMasteryBySummoner: {
-    path: 'champion-masteries/by-summoner/$(encryptedSummonerId)',
+  ChampionMasteryByPUUID: {
+    path: 'champion-masteries/by-puuid/$(summonerPUUID)',
     prefix: 'champion-mastery',
     version: 4
   },
-  ChampionMasteryBySummonerChampion: {
-    path: 'champion-masteries/by-summoner/$(encryptedSummonerId)/by-champion/$(championId)',
+  ChampionMasteryByPUUIDChampion: {
+    path: 'champion-masteries/by-puuid/$(summonerPUUID)/by-champion/$(championId)',
     prefix: 'champion-mastery',
     version: 4
   },
   ChampionsScore: {
-    path: 'scores/by-summoner/$(encryptedSummonerId)',
+    path: 'scores/by-puuid/$(summonerPUUID)',
     prefix: 'champion-mastery',
     version: 4
   },


### PR DESCRIPTION
As Riot Games deprecated by-summoner endpoints current ones are invalid.
This PR contains new endpoints and namings.

if i've missed something LMK!