### PR TITLE
Fixed typo on LeagueEntryDTO.dto.ts

### DIFF
--- a/src/models-dto/league/tft-league/LeagueEntryDTO.dto.ts
+++ b/src/models-dto/league/tft-league/LeagueEntryDTO.dto.ts
@@ -9,7 +9,7 @@ export class LeagueEntryDTO {
   readonly rank: string
   readonly leaguePoints: number
   readonly wins: number
-  readonly loses: number
+  readonly losses: number
   readonly hotstreak: boolean
   readonly veteran: boolean
   readonly freshBlood: boolean


### PR DESCRIPTION
Riot API returns "losses" so there is a typo error in the class