### PR TITLE
Update match-tft-query.dto.ts with missing query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.60.1",
+  "version": "1.60.2",
   "description": "Fetching riot games api data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/models-dto/matches/tft-matches/match-tft-query.dto.ts
+++ b/src/models-dto/matches/tft-matches/match-tft-query.dto.ts
@@ -3,4 +3,19 @@ export class MatchTFTQueryDTO {
    * Number of TFT Matches to list
    */
   count?: number
+
+  /**
+   * Ignore the first respective TFT Matches. Defaults to 0.
+   */
+  start?: number
+
+  /**
+   * Epoch timestamp in seconds. The matchlist started storing timestamps on June 16th, 2021. Any matches played before June 16th, 2021 won't be included in the results if the startTime filter is set.
+   */
+  startTime?: number
+
+  /**
+   * Epoch timestamp in seconds.
+   */
+  endTime?: number
 }


### PR DESCRIPTION
Update of query params available on RIOT API for match request (https://developer.riotgames.com/apis#tft-match-v1/GET_getMatchIdsByPUUID).

Added the following options:
- start (Defaults to 0. Start index.)
- startTime (Epoch timestamp in seconds. The matchlist started storing timestamps on June 16th, 2021. Any matches played before June 16th, 2021 won't be included in the results if the startTime filter is set.)
- endTime (Epoch timestamp in seconds.)