### PR TITLE
update constants for SEA merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.61.5",
+  "version": "1.62.0",
   "description": "Fetching riot games api data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants/champions.ts
+++ b/src/constants/champions.ts
@@ -171,6 +171,8 @@ export enum Champions {
   KSANTE = 897,
   MILIO = 902,
   HWEI = 910,
+  AURORA = 893,
+  AMBESSA = 799
 }
 
 const championIdMap = invert(Champions)

--- a/src/constants/regions.test.ts
+++ b/src/constants/regions.test.ts
@@ -23,9 +23,7 @@ describe('Regions', () => {
 
     it('should match sea', () => {
       expect(regionToRegionGroup(Regions.OCEANIA)).toEqual(RegionGroups.SEA)
-      expect(regionToRegionGroup(Regions.PHILIPPINES)).toEqual(RegionGroups.SEA)
       expect(regionToRegionGroup(Regions.SINGAPORE)).toEqual(RegionGroups.SEA)
-      expect(regionToRegionGroup(Regions.THAILAND)).toEqual(RegionGroups.SEA)
       expect(regionToRegionGroup(Regions.TAIWAN)).toEqual(RegionGroups.SEA)
       expect(regionToRegionGroup(Regions.VIETNAM)).toEqual(RegionGroups.SEA)
     })

--- a/src/constants/regions.ts
+++ b/src/constants/regions.ts
@@ -12,9 +12,7 @@ export enum Regions {
   JAPAN = 'JP1',
   VIETNAM = 'VN2',
   TAIWAN = 'TW2',
-  THAILAND = 'TH2',
   SINGAPORE = 'SG2', 
-  PHILIPPINES = 'PH2',
   MIDDLE_EAST = 'ME1',
   PBE = 'PBE1',
 }
@@ -55,9 +53,7 @@ export function regionToRegionGroup (region: Regions): RegionGroups {
       return RegionGroups.ASIA
     // Sea
     case Regions.OCEANIA:
-    case Regions.PHILIPPINES:
     case Regions.SINGAPORE:
-    case Regions.THAILAND:
     case Regions.TAIWAN:
     case Regions.VIETNAM:
       return RegionGroups.SEA


### PR DESCRIPTION
- package version 1.61.5 -> 1.62.0
- add aurora & ambessa ids (mentioned #128)
- removed `ph2` & `th2` for [SEA merge](https://www.leagueoflegends.com/en-sg/news/announcements/the-sea-server-merge-is-coming/).