### PR TITLE
Implement #131 (custom baseURL for rate limiting proxies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ const api = new LolApi({
    */
   key: '',
   /**
+   * BaseURL for a rate limiting proxy (default: "https://$(region).api.riotgames.com/:game")
+   * Using this field is for a very advanced use case and in most cases not necessary
+   * ${region} and :game are expected but not required variables
+   */
+  baseURL: "http://localhost:8080/${region}/:game",
+  /**
    * Debug methods
    */
   debug: {

--- a/src/base/base.ts
+++ b/src/base/base.ts
@@ -19,7 +19,7 @@ config()
 
 export class BaseApi<Region extends string> {
   protected readonly game: BaseApiGames = BaseApiGames.LOL
-  private readonly baseUrl = BaseConstants.BASE_URL
+  private baseUrl: string = BaseConstants.BASE_URL
   private key: string
   private concurrency: number | undefined
   private rateLimitRetry: boolean = true
@@ -66,6 +66,9 @@ export class BaseApi<Region extends string> {
       if (typeof param.debug.logRatelimits !== 'undefined') {
         _.set(this.debug, 'logRatelimits', param.debug.logRatelimits)
       }
+    }
+    if(typeof param.baseURL !== 'undefined') {
+      this.baseUrl = param.baseURL
     }
     this.concurrency = param.concurrency
     if (typeof param.concurrency !== 'undefined') {
@@ -187,6 +190,7 @@ export class BaseApi<Region extends string> {
       rateLimitRetry: this.rateLimitRetry,
       rateLimitRetryAttempts: this.rateLimitRetryAttempts,
       concurrency: this.concurrency,
+      baseURL: this.baseUrl,
       debug: this.debug
     }
   }

--- a/src/base/base.utils.ts
+++ b/src/base/base.utils.ts
@@ -24,6 +24,11 @@ export interface IBaseApiParams {
    */
   concurrency?: number,
   /**
+   * BaseURL for a rate limiting proxy (default: "https://$(region).api.riotgames.com/:game")
+   * ${region} and :game are expected but not required variables
+   */
+  baseURL?: string
+  /**
    * Debug methods
    */
   debug?: {

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -1,3 +1,4 @@
+import { BaseConstants } from './../src/base/base.const';
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { BaseApi } = require('../src/base/base')
 const { getUrlFromOptions } = require('../src/base/base.utils')
@@ -47,6 +48,7 @@ describe('Base api', () => {
       const exp = {
         concurrency: undefined,
         key,
+        baseURL: BaseConstants.BASE_URL,
         rateLimitRetry: true,
         rateLimitRetryAttempts: 1,
         debug: {
@@ -56,6 +58,16 @@ describe('Base api', () => {
         }
       }
       expect(api.getParam()).toEqual(exp)
+    })
+
+    it('should return new base path if set', () => {
+      const newBaseURL = "${region}/:game"
+      const api = new BaseApi({
+        key: key,
+        baseURL: newBaseURL
+      });
+
+      expect(api.getParam().baseURL).toBe(newBaseURL)
     })
   })
 


### PR DESCRIPTION
- Added the possibility to change the baseURL when using an internal rate limit proxy
- Documented the changes
- Added tests
- Pointed out that changing this variable will usually break everything if not implemented correctly

I decided to add no "verification" whether the new baseURL is correct or not, the user will realize that quickly enough or it might even not be necessary to e.g. support region as the proxy only supports a single region / game. 

I could implement it in a way that the whole `IEndpoint` pathing can be modified but that seemed overkill. It is totally possible tho with the regex path parsing which is already in place. 