### PR TITLE
fix(account): Change to correct available regions for the AccountV1 API

### DIFF
--- a/src/apis/riot/account/account.ts
+++ b/src/apis/riot/account/account.ts
@@ -1,4 +1,4 @@
-import { RegionGroups, Games } from "../../../constants";
+import { AccountAPIRegionGroups, Games } from "../../../constants";
 import { endpointsRiotV1 } from "../../../endpoints/endpoints";
 import { BaseApiRiot } from "../base/base.api.riot";
 import { AccountDto } from "../../../models-dto/account/account.dto";
@@ -10,7 +10,7 @@ export class AccountV1Api extends BaseApiRiot {
    * @param puuid
    *
    */
-  public async getByPUUID(puuid: string, region: RegionGroups) {
+  public async getByPUUID(puuid: string, region: AccountAPIRegionGroups) {
     const params = {
       summonerPUUID: puuid,
     };
@@ -24,7 +24,7 @@ export class AccountV1Api extends BaseApiRiot {
    * @param region
    *
    */
-  public async getByRiotId(gameName: string, tagLine: string, region: RegionGroups) {
+  public async getByRiotId(gameName: string, tagLine: string, region: AccountAPIRegionGroups) {
     const params = {
       gameName,
       tagLine,
@@ -39,7 +39,7 @@ export class AccountV1Api extends BaseApiRiot {
    * @param region
    *
    */
-  public async getActiveRegion(puuid: string, game: Games, region: RegionGroups) {
+  public async getActiveRegion(puuid: string, game: Games, region: AccountAPIRegionGroups) {
     const params = {
       summonerPUUID: puuid,
       game: game,

--- a/src/constants/regions.ts
+++ b/src/constants/regions.ts
@@ -32,6 +32,9 @@ export enum RegionGroups {
   SEA = 'SEA'
 }
 
+// See riot API: There are three routing values for account-v1; americas, asia, and europe. You can query for any account in any region. We recommend using the nearest cluster.
+export type AccountAPIRegionGroups = Exclude<RegionGroups, RegionGroups.SEA>;
+
 export function regionToRegionGroup (region: Regions): RegionGroups {
   switch (region) {
     // America
@@ -59,4 +62,12 @@ export function regionToRegionGroup (region: Regions): RegionGroups {
       return RegionGroups.SEA
   }
   throw new Error(`Unexpected region: ${region}`)
+}
+
+export function regionToRegionGroupForAccountAPI(region: Regions): AccountAPIRegionGroups {
+  const regionGroup = regionToRegionGroup(region);
+  if(regionGroup === RegionGroups.SEA){
+    return RegionGroups.ASIA;
+  }
+  return regionGroup;
 }


### PR DESCRIPTION
- As described in the Riot Docs this API is only available for americas, asia, and europe. Otherwise Request will fail
- Added correct type to reflect that
- added helper method to convert the region