### PR TITLE
docs: capitalise company name and repo purpose in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Twisted
-League of legends api wrapper <br>
+League of Legends API Wrapper <br>
 ![https://www.npmjs.com/package/twisted](https://nodei.co/npm/twisted.png)
 
 # Simple example


### PR DESCRIPTION
Ensures the README title follows our style guide:
- Company name in full caps
- Clear statement of repo purpose No code changes.