### PR TITLE
LeagueByPuuid path has no entries/

### DIFF
--- a/src/endpoints/endpoints.ts
+++ b/src/endpoints/endpoints.ts
@@ -198,13 +198,13 @@ export const endpointsTFTV1: IEndpoints = {
   },
 
   LeagueBySummoner: {
-    path: 'entries/by-summoner/$(encryptedSummonerId)',
+    path: 'by-summoner/$(encryptedSummonerId)',
     prefix: 'league',
     version: 1
   },
 
   LeagueByPuuid: {
-    path: 'entries/by-puuid/$(puuid)',
+    path: 'by-puuid/$(puuid)',
     prefix: 'league',
     version: 1
   },


### PR DESCRIPTION
The constant endpointsTFTV1.LeagueByPuuid  path has no entries URL:https://na1.api.riotgames.com/tft/league/v1/by-puuid/{puuid}

API:https://developer.riotgames.com/apis#tft-league-v1/GET_getLeagueEntriesByPUUID