### PR TITLE
feat(ddragon): Support for specifying languages for `getRunesReforged` and `getChampion` methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twisted",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "description": "Fetching riot games api data",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/apis/lol/dataDragon/DataDragonService.ts
+++ b/src/apis/lol/dataDragon/DataDragonService.ts
@@ -44,18 +44,27 @@ export class DataDragonService {
   /**
    * Runes reforged (perks)
    */
-  async getRunesReforged (): Promise<RunesReforgedDTO[]> {
+  async getRunesReforged (language?: string): Promise<RunesReforgedDTO[]> {
     const version = (await this.getVersions())[0]
-    const path = `cdn/${version}/data/${defaultLang}/runesReforged.json`
+    const lang = language || defaultLang;
+    const path = `cdn/${version}/data/${lang}/runesReforged.json`
+    return this.request(path)
+  }
+
+  async getChampionList (language?: string): Promise<ChampionsDataDragon> {
+    const version = (await this.getVersions())[0]
+    const lang = language || defaultLang
+    const path = `cdn/${version}/data/${lang}/champion.json`
     return this.request(path)
   }
 
   async getChampion (): Promise<ChampionsDataDragon>
-  async getChampion (champ: Champions | number): Promise<ChampionsDataDragonDetailsSolo>
-  async getChampion (champ?: Champions): Promise<ChampionsDataDragon | ChampionsDataDragonDetailsSolo> {
+  async getChampion (champ: Champions | number, language?: string ): Promise<ChampionsDataDragonDetailsSolo>
+  async getChampion (champ?: Champions, language?: string ): Promise<ChampionsDataDragon | ChampionsDataDragonDetailsSolo> {
     const version = (await this.getVersions())[0]
+    const lang = language || defaultLang
     let champName = ''
-    let path = `cdn/${version}/data/${defaultLang}/champion`
+    let path = `cdn/${version}/data/${lang}/champion`
     if (champ) {
       champName = getChampionNameCapital(champ)
       path += `/${champName}.json`

--- a/src/apis/lol/dataDragon/DataDragonService.ts
+++ b/src/apis/lol/dataDragon/DataDragonService.ts
@@ -46,7 +46,7 @@ export class DataDragonService {
    */
   async getRunesReforged (language?: string): Promise<RunesReforgedDTO[]> {
     const version = (await this.getVersions())[0]
-    const lang = language || defaultLang;
+    const lang = language || defaultLang
     const path = `cdn/${version}/data/${lang}/runesReforged.json`
     return this.request(path)
   }


### PR DESCRIPTION
Added support for specifying the language for the  `getRunesReforged` and `getChampion` methods of the Data Dragon Service (Defaults to `en_US`).

I wasn't sure how to include the param in `getChampion()` to get all champions without making a breaking change, so I added a new method `getChampionList(language)`. Let me know if that's ok.

Examples
```js
api.DataDragon.getRunesReforged('es_MX')

api.DataDragon.getChampion(777, 'es_MX')

api.DataDragon.getChampionList('es_MX')
```
