### PR TITLE
Fixes on ChampionsDataDragonDetailsSolo typings

### DIFF
--- a/src/models-dto/data-dragon/champions.datadragon.dto.ts
+++ b/src/models-dto/data-dragon/champions.datadragon.dto.ts
@@ -79,11 +79,20 @@ export class ChampionsDataDragonDetailsSolo extends ChampionsDataDragonDetails {
       key: string
     }[]
     costType: string
-    maxamo: string
+    maxammo: string
     range: number[]
     rangeBurn: string
+    image: {
+      full: string
+      sprite: string
+      group: string
+      x: number
+      y: number
+      w: number
+      h: number
+    }
     resource: string
-  }
+  }[]
   passive: {
     name: string
     description: string


### PR DESCRIPTION
Fixed a typo in max ammo, made ChampionsDataDragonDetailsSolo.spells an array and added the image property to ChampionsDataDragonDetailsSolo